### PR TITLE
:sparkles: DB + Visitors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+    FROM gradle:8.10-jdk17-alpine AS builder
+
+    WORKDIR /home/gradle/project
+    
+    COPY . .
+    
+    RUN gradle :beowulf-cli:installDist --no-daemon
+    
+    FROM eclipse-temurin:17-jre
+    
+    RUN apt-get update \
+        && apt-get install -y --no-install-recommends rar \
+        && ln -s /usr/bin/rar /usr/local/bin/rar \
+        && rm -rf /var/lib/apt/lists/*
+    
+    WORKDIR /app
+    
+    COPY --from=builder /home/gradle/project/beowulf-cli/build/install/beowulf-cli ./beowulf-cli
+    
+    # Per-user Beowulf config (~/.beowulf)
+    ENV HOME=/root
+    
+    ENTRYPOINT ["./beowulf-cli/bin/beowulf-cli"]
+    CMD ["help"]
+    

--- a/beowulf-cli/src/main/java/com/beowulf/cli/BeowulfCLI.java
+++ b/beowulf-cli/src/main/java/com/beowulf/cli/BeowulfCLI.java
@@ -1,7 +1,176 @@
 package com.beowulf.cli;
 
+import com.beowulf.core.db.DbMigrations;
+import com.beowulf.core.factory.ArchiverFactory;
+import com.beowulf.core.visitor.ArchiveLogEntry;
+import com.beowulf.core.visitor.ArchiveLogQueryService;
+import com.beowulf.core.visitor.ArchivePersistenceService;
+import com.beowulf.core.visitor.LoggingArchiver;
+import com.beowulf.core.visitor.PersistArchiveVisitor;
+import com.beowulf.core.strategy.Archiver;
+import com.beowulf.core.user.AppUser;
+import com.beowulf.core.user.LocalUserIdentityProvider;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
 public class BeowulfCLI {
+
+    private static final ArchiverFactory factory = new ArchiverFactory();
+
+    private static LocalUserIdentityProvider identityProvider;
+    private static ArchivePersistenceService persistenceService;
+    private static PersistArchiveVisitor persistVisitor;
+    private static ArchiveLogQueryService logQueryService;
+
     public static void main(String[] args) {
-        System.out.println("Hello, World!");
+
+        DbMigrations.migrate();
+
+        identityProvider = new LocalUserIdentityProvider();
+        persistenceService = new ArchivePersistenceService();
+        persistVisitor = new PersistArchiveVisitor(persistenceService);
+        logQueryService = new ArchiveLogQueryService();
+
+        if (args.length < 1) {
+            printUsage();
+            return;
+        }
+
+        String command = args[0];
+
+        try {
+            switch (command) {
+
+                case "compress" -> handleCompress(args);
+                case "decompress" -> handleDecompress(args);
+                case "logs" -> handleLogs(args);
+                case "help" -> printUsage();
+
+                default -> {
+                    System.out.println("Unknown command: " + command);
+                    printUsage();
+                }
+            }
+        } catch (Exception error) {
+            System.err.println("ERROR: " + error.getMessage());
+            error.printStackTrace();
+            System.exit(1);
+        }
+    }
+
+    private static void handleCompress(String[] args) throws IOException {
+        if (args.length != 3) {
+            System.err.println("Invalid usage for compress.");
+            System.err.println("Usage: beowulf compress <sourceDir> <targetArchive>");
+            return;
+        }
+
+        Path sourceDir = Paths.get(args[1]);
+        Path targetArchive = Paths.get(args[2]);
+
+        Archiver baseArchiver = factory.getArchiver(targetArchive);
+        Archiver archiver = new LoggingArchiver(
+                baseArchiver,
+                identityProvider,
+                persistVisitor);
+
+        System.out.println("→ Compressing using " + archiver.getName());
+        archiver.compress(sourceDir, targetArchive);
+        System.out.println("✓ Done: " + targetArchive);
+    }
+
+    private static void handleDecompress(String[] args) throws IOException {
+        if (args.length != 3) {
+            System.err.println("Invalid usage for decompress.");
+            System.err.println("Usage: beowulf decompress <archive> <targetDir>");
+            return;
+        }
+
+        Path archive = Paths.get(args[1]);
+        Path targetDir = Paths.get(args[2]);
+
+        Archiver baseArchiver = factory.getArchiver(archive);
+        Archiver archiver = new LoggingArchiver(
+                baseArchiver,
+                identityProvider,
+                persistVisitor);
+
+        System.out.println("→ Decompressing using " + archiver.getName());
+        archiver.decompress(archive, targetDir);
+        System.out.println("✓ Extracted to: " + targetDir);
+    }
+
+    private static void handleLogs(String[] args) {
+        int limit = 20;
+        if (args.length >= 2) {
+            try {
+                limit = Integer.parseInt(args[1]);
+            } catch (NumberFormatException error) {
+                System.err.println("Invalid limit: " + args[1] + ". Using default: 20");
+            }
+        }
+
+        AppUser user = identityProvider.resolveCurrentUser();
+        List<ArchiveLogEntry> entries = logQueryService.findRecentLogs(user.getId(), limit);
+
+        if (entries.isEmpty()) {
+            System.out.println("No logs for current user: " + user.getUsername()
+                    + " (" + user.getId() + ")");
+            return;
+        }
+
+        System.out.println("Beowulf logs for user: " + user.getUsername()
+                + " (" + user.getId() + ")");
+        System.out.println("Last " + entries.size() + " operations:\n");
+
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+        for (ArchiveLogEntry entry : entries) {
+            String createdAt = entry.getCreatedAt() != null ? entry.getCreatedAt().format(formatter) : "?";
+            System.out.printf(
+                    "[%d] %s | %-9s | %-7s | %6d ms%n",
+                    entry.getId(),
+                    createdAt,
+                    entry.getOperation(),
+                    entry.getStatus(),
+                    entry.getDurationMs());
+            System.out.printf(
+                    "    Archive : %s (%s / %s, %d bytes)%n",
+                    entry.getArchivePath(),
+                    entry.getFormat(),
+                    entry.getCompression(),
+                    entry.getSizeBytes());
+            System.out.printf(
+                    "    Checksum: %s %s%n",
+                    entry.getChecksumType(),
+                    entry.getChecksumValue());
+            System.out.println();
+        }
+    }
+
+    private static void printUsage() {
+        System.out.println("""
+                Beowulf CLI
+                ---------------------
+                Usage:
+                  beowulf compress <sourceDir> <targetArchive>
+                  beowulf decompress <archiveFile> <targetDir>
+                  beowulf logs [limit]
+
+                Examples:
+                  beowulf compress ./source beowulf.zip
+                  beowulf compress ./folder data.tar.gz
+                  beowulf decompress archive.rar ./output
+                  beowulf logs
+                  beowulf logs 10
+
+                Supported formats:
+                  ZIP, TAR.GZ, TGZ, RAR, ACE (extract-only)
+
+                """);
     }
 }

--- a/beowulf-core/build.gradle.kts
+++ b/beowulf-core/build.gradle.kts
@@ -4,4 +4,8 @@ plugins {
 
 dependencies {
     implementation("org.apache.commons:commons-compress:1.27.0")
+    implementation("org.postgresql:postgresql:42.7.3")
+    implementation("com.zaxxer:HikariCP:5.1.0")
+    implementation("org.flywaydb:flyway-database-postgresql:10.18.0")
+    runtimeOnly("org.slf4j:slf4j-nop:2.0.16")
 }

--- a/beowulf-core/src/main/java/com/beowulf/core/adapter/TarGzAdapter.java
+++ b/beowulf-core/src/main/java/com/beowulf/core/adapter/TarGzAdapter.java
@@ -27,23 +27,45 @@ public class TarGzAdapter {
         if (!Files.exists(sourceDir))
             throw new FileNotFoundException("Source directory not found: " + sourceDir);
 
+        Path parent = sourceDir.getParent();
+        Path base = parent != null ? parent : sourceDir;
+
         try (OutputStream filOutputStream = Files.newOutputStream(targetArchive);
                 BufferedOutputStream bufferedOutputStream = new BufferedOutputStream(filOutputStream);
                 GZIPOutputStream gzipOutputStream = new GZIPOutputStream(bufferedOutputStream);
                 TarArchiveOutputStream tarArchiveOutputStream = new TarArchiveOutputStream(gzipOutputStream)) {
 
-            Files.walk(sourceDir)
-                    .filter(Files::isRegularFile)
-                    .forEach(path -> {
-                        String entryName = sourceDir.relativize(path).toString();
+            tarArchiveOutputStream.setLongFileMode(TarArchiveOutputStream.LONGFILE_GNU);
 
-                        try (InputStream in = Files.newInputStream(path)) {
-                            TarArchiveEntry entry = new TarArchiveEntry(path.toFile(), entryName);
-                            tarArchiveOutputStream.putArchiveEntry(entry);
-                            IOUtils.copy(in, tarArchiveOutputStream);
-                            tarArchiveOutputStream.closeArchiveEntry();
-                        } catch (IOException error) {
-                            throw new UncheckedIOException("TAR.GZ compression failed", error);
+            Files.walk(sourceDir)
+                    .forEach(path -> {
+                        try {
+                            Path relativePath = base.relativize(path);
+                            String entryName = relativePath.toString().replace(File.separatorChar, '/');
+
+                            if (entryName.isEmpty()) {
+                                return;
+                            }
+
+                            if (Files.isDirectory(path)) {
+                                if (!entryName.endsWith("/")) {
+                                    entryName = entryName + "/";
+                                }
+
+                                TarArchiveEntry dirEntry = new TarArchiveEntry(entryName);
+                                dirEntry.setModTime(Files.getLastModifiedTime(path).toMillis());
+                                tarArchiveOutputStream.putArchiveEntry(dirEntry);
+                                tarArchiveOutputStream.closeArchiveEntry();
+                            } else {
+                                TarArchiveEntry fileEntry = new TarArchiveEntry(path.toFile(), entryName);
+                                tarArchiveOutputStream.putArchiveEntry(fileEntry);
+                                try (InputStream in = Files.newInputStream(path)) {
+                                    IOUtils.copy(in, tarArchiveOutputStream);
+                                }
+                                tarArchiveOutputStream.closeArchiveEntry();
+                            }
+                        } catch (IOException e) {
+                            throw new UncheckedIOException("TAR.GZ compression failed", e);
                         }
                     });
 

--- a/beowulf-core/src/main/java/com/beowulf/core/adapter/ZipAdapter.java
+++ b/beowulf-core/src/main/java/com/beowulf/core/adapter/ZipAdapter.java
@@ -26,20 +26,41 @@ public class ZipAdapter {
             throw new FileNotFoundException("Source directory not found: " + sourceDir);
         }
 
+        Path parent = sourceDir.getParent();
+        Path base = parent != null ? parent : sourceDir;
+
         try (OutputStream outputStream = Files.newOutputStream(targetArchive);
                 BufferedOutputStream bufferedOutputStream = new BufferedOutputStream(outputStream);
                 ZipArchiveOutputStream zipArchiveOutputStream = new ZipArchiveOutputStream(bufferedOutputStream)) {
 
-            Files.walk(sourceDir)
-                    .filter(Files::isRegularFile)
-                    .forEach(path -> {
-                        String entryName = sourceDir.relativize(path).toString();
+            zipArchiveOutputStream.setLevel(ZipArchiveOutputStream.STORED);
 
-                        try (InputStream fileInputStream = Files.newInputStream(path)) {
-                            ZipArchiveEntry entry = new ZipArchiveEntry(entryName);
-                            zipArchiveOutputStream.putArchiveEntry(entry);
-                            IOUtils.copy(fileInputStream, zipArchiveOutputStream);
-                            zipArchiveOutputStream.closeArchiveEntry();
+            Files.walk(sourceDir)
+                    .forEach(path -> {
+                        try {
+                            Path relativePath = base.relativize(path);
+                            String entryName = relativePath.toString().replace(File.separatorChar, '/');
+
+                            if (entryName.isEmpty()) {
+                                return;
+                            }
+
+                            if (Files.isDirectory(path)) {
+                                if (!entryName.endsWith("/")) {
+                                    entryName = entryName + "/";
+                                }
+                                ZipArchiveEntry dirEntry = new ZipArchiveEntry(entryName);
+                                dirEntry.setTime(Files.getLastModifiedTime(path).toMillis());
+                                zipArchiveOutputStream.putArchiveEntry(dirEntry);
+                                zipArchiveOutputStream.closeArchiveEntry();
+                            } else {
+                                try (InputStream fileInputStream = Files.newInputStream(path)) {
+                                    ZipArchiveEntry entry = new ZipArchiveEntry(entryName);
+                                    zipArchiveOutputStream.putArchiveEntry(entry);
+                                    IOUtils.copy(fileInputStream, zipArchiveOutputStream);
+                                    zipArchiveOutputStream.closeArchiveEntry();
+                                }
+                            }
                         } catch (IOException error) {
                             throw new UncheckedIOException("ZIP compression failed", error);
                         }

--- a/beowulf-core/src/main/java/com/beowulf/core/db/DataSourceFactory.java
+++ b/beowulf-core/src/main/java/com/beowulf/core/db/DataSourceFactory.java
@@ -1,0 +1,38 @@
+package com.beowulf.core.db;
+
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+
+import javax.sql.DataSource;
+
+public final class DataSourceFactory {
+
+    private static HikariDataSource dataSource;
+
+    private DataSourceFactory() {
+    }
+
+    public static DataSource getDataSource() {
+        if (dataSource == null) {
+            HikariConfig config = new HikariConfig();
+
+            config.setJdbcUrl("jdbc:postgresql://postgres:5432/beowulf_db");
+
+            config.setUsername("beowulf");
+            config.setPassword("beowulf");
+
+            config.setMaximumPoolSize(10);
+            config.setMinimumIdle(1);
+            config.setPoolName("BeowulfHikariPool");
+
+            dataSource = new HikariDataSource(config);
+        }
+        return dataSource;
+    }
+
+    public static void close() {
+        if (dataSource != null) {
+            dataSource.close();
+        }
+    }
+}

--- a/beowulf-core/src/main/java/com/beowulf/core/db/DbMigrations.java
+++ b/beowulf-core/src/main/java/com/beowulf/core/db/DbMigrations.java
@@ -1,0 +1,23 @@
+package com.beowulf.core.db;
+
+import org.flywaydb.core.Flyway;
+
+import javax.sql.DataSource;
+
+public final class DbMigrations {
+
+    private DbMigrations() {
+    }
+
+    public static void migrate() {
+        DataSource dataSource = DataSourceFactory.getDataSource();
+
+        Flyway flyway = Flyway.configure()
+                .dataSource(dataSource)
+                .locations("classpath:db/migration")
+                .baselineOnMigrate(true)
+                .load();
+
+        flyway.migrate();
+    }
+}

--- a/beowulf-core/src/main/java/com/beowulf/core/facade/ArchiveService.java
+++ b/beowulf-core/src/main/java/com/beowulf/core/facade/ArchiveService.java
@@ -1,0 +1,21 @@
+package com.beowulf.core.facade;
+
+import com.beowulf.core.factory.ArchiverFactory;
+import com.beowulf.core.strategy.Archiver;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+public class ArchiveService {
+    private final ArchiverFactory factory = new ArchiverFactory();
+
+    public void compress(Path sourceDir, Path targetArchive) throws IOException {
+        Archiver archiver = factory.getArchiver(targetArchive);
+        archiver.compress(sourceDir, targetArchive);
+    }
+
+    public void decompress(Path archive, Path targetDir) throws IOException {
+        Archiver archiver = factory.getArchiver(archive);
+        archiver.decompress(archive, targetDir);
+    }
+}

--- a/beowulf-core/src/main/java/com/beowulf/core/factory/ArchiverFactory.java
+++ b/beowulf-core/src/main/java/com/beowulf/core/factory/ArchiverFactory.java
@@ -1,0 +1,35 @@
+package com.beowulf.core.factory;
+
+import com.beowulf.core.strategy.*;
+
+import java.nio.file.Path;
+import java.util.Locale;
+
+public class ArchiverFactory {
+
+    /**
+     * Returns an Archiver strategy based on the file extension.
+     */
+    public Archiver getArchiver(Path archive) {
+        String name = archive.getFileName().toString().toLowerCase(Locale.ROOT);
+
+        if (name.endsWith(".tar.gz") || name.endsWith(".tgz")) {
+            return new TarGzArchiver();
+        }
+
+        if (name.endsWith(".zip")) {
+            return new ZipArchiver();
+        }
+
+        if (name.endsWith(".rar")) {
+            return new RarArchiver();
+        }
+
+        if (name.endsWith(".ace")) {
+            return new AceArchiver();
+        }
+
+        throw new IllegalArgumentException("Unsupported archive format: " + name);
+    }
+
+}

--- a/beowulf-core/src/main/java/com/beowulf/core/user/AppUser.java
+++ b/beowulf-core/src/main/java/com/beowulf/core/user/AppUser.java
@@ -1,0 +1,35 @@
+package com.beowulf.core.user;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+public class AppUser {
+
+    private UUID id;
+    private String username;
+    private OffsetDateTime createdAt;
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public OffsetDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(OffsetDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+}

--- a/beowulf-core/src/main/java/com/beowulf/core/user/LocalUserIdentityProvider.java
+++ b/beowulf-core/src/main/java/com/beowulf/core/user/LocalUserIdentityProvider.java
@@ -1,0 +1,111 @@
+package com.beowulf.core.user;
+
+import com.beowulf.core.db.DataSourceFactory;
+
+import javax.sql.DataSource;
+import java.io.*;
+import java.nio.file.*;
+import java.sql.*;
+import java.time.OffsetDateTime;
+import java.util.Properties;
+import java.util.UUID;
+
+public class LocalUserIdentityProvider {
+
+    private static final String CONFIG_DIR = System.getProperty("user.home") + File.separator + ".beowulf";
+    private static final String CONFIG_FILE = CONFIG_DIR + File.separator + "config.properties";
+    private static final String KEY_USER_ID = "user.id";
+
+    private final DataSource dataSource;
+
+    public LocalUserIdentityProvider() {
+        this.dataSource = DataSourceFactory.getDataSource();
+    }
+
+    public AppUser resolveCurrentUser() {
+        UUID userId = loadOrCreateLocalUserId();
+        AppUser user = findUserById(userId);
+        if (user != null) {
+            return user;
+        }
+        AppUser newUser = new AppUser();
+        newUser.setId(userId);
+        newUser.setUsername(System.getProperty("user.name", "unknown"));
+        return insertUser(newUser);
+    }
+
+    private UUID loadOrCreateLocalUserId() {
+        try {
+            Properties props = new Properties();
+            Path path = Paths.get(CONFIG_FILE);
+
+            if (Files.exists(path)) {
+                try (InputStream in = Files.newInputStream(path)) {
+                    props.load(in);
+                }
+                String idStr = props.getProperty(KEY_USER_ID);
+                if (idStr != null && !idStr.isBlank()) {
+                    return UUID.fromString(idStr.trim());
+                }
+            }
+
+            Files.createDirectories(Paths.get(CONFIG_DIR));
+            UUID newId = UUID.randomUUID();
+            props.setProperty(KEY_USER_ID, newId.toString());
+            try (OutputStream out = Files.newOutputStream(path)) {
+                props.store(out, "Beowulf local user config");
+            }
+            return newId;
+        } catch (IOException error) {
+            throw new RuntimeException("Failed to load/create local user id", error);
+        }
+    }
+
+    private AppUser findUserById(UUID id) {
+        String sql = """
+                SELECT id, username, created_at
+                FROM app_user
+                WHERE id = ?
+                """;
+
+        try (Connection connection = dataSource.getConnection();
+                PreparedStatement preparedStatement = connection.prepareStatement(sql)) {
+            preparedStatement.setObject(1, id);
+            try (ResultSet resultSet = preparedStatement.executeQuery()) {
+                if (resultSet.next()) {
+                    AppUser user = new AppUser();
+                    user.setId((UUID) resultSet.getObject("id"));
+                    user.setUsername(resultSet.getString("username"));
+                    user.setCreatedAt(resultSet.getObject("created_at", OffsetDateTime.class));
+                    return user;
+                }
+            }
+            return null;
+        } catch (SQLException error) {
+            throw new RuntimeException("Failed to load app_user", error);
+        }
+    }
+
+    private AppUser insertUser(AppUser user) {
+        String sql = """
+                INSERT INTO app_user (id, username)
+                VALUES (?, ?)
+                RETURNING created_at
+                """;
+
+        try (Connection connection = dataSource.getConnection();
+                PreparedStatement preparedStatement = connection.prepareStatement(sql)) {
+            preparedStatement.setObject(1, user.getId());
+            preparedStatement.setString(2, user.getUsername());
+
+            try (ResultSet resultSet = preparedStatement.executeQuery()) {
+                if (resultSet.next()) {
+                    user.setCreatedAt(resultSet.getObject("created_at", OffsetDateTime.class));
+                }
+            }
+            return user;
+        } catch (SQLException error) {
+            throw new RuntimeException("Failed to insert app_user", error);
+        }
+    }
+}

--- a/beowulf-core/src/main/java/com/beowulf/core/visitor/ArchiveLogEntry.java
+++ b/beowulf-core/src/main/java/com/beowulf/core/visitor/ArchiveLogEntry.java
@@ -1,0 +1,110 @@
+package com.beowulf.core.visitor;
+
+import java.time.OffsetDateTime;
+
+public class ArchiveLogEntry {
+
+    private long id;
+    private OffsetDateTime createdAt;
+
+    private String operation; // COMPRESS / DECOMPRESS
+    private String status; // SUCCESS / FAILED
+    private long durationMs;
+
+    private String archivePath; // archive.path
+
+    private String format; // ZIP / TAR / ...
+    private String compression; // GZIP / BZIP2 / ...
+    private long sizeBytes;
+
+    private String checksumType; // CRC32 / SHA256
+    private String checksumValue;
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public OffsetDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(OffsetDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public String getOperation() {
+        return operation;
+    }
+
+    public void setOperation(String operation) {
+        this.operation = operation;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public long getDurationMs() {
+        return durationMs;
+    }
+
+    public void setDurationMs(long durationMs) {
+        this.durationMs = durationMs;
+    }
+
+    public String getArchivePath() {
+        return archivePath;
+    }
+
+    public void setArchivePath(String archivePath) {
+        this.archivePath = archivePath;
+    }
+
+    public String getFormat() {
+        return format;
+    }
+
+    public void setFormat(String format) {
+        this.format = format;
+    }
+
+    public String getCompression() {
+        return compression;
+    }
+
+    public void setCompression(String compression) {
+        this.compression = compression;
+    }
+
+    public long getSizeBytes() {
+        return sizeBytes;
+    }
+
+    public void setSizeBytes(long sizeBytes) {
+        this.sizeBytes = sizeBytes;
+    }
+
+    public String getChecksumType() {
+        return checksumType;
+    }
+
+    public void setChecksumType(String checksumType) {
+        this.checksumType = checksumType;
+    }
+
+    public String getChecksumValue() {
+        return checksumValue;
+    }
+
+    public void setChecksumValue(String checksumValue) {
+        this.checksumValue = checksumValue;
+    }
+}

--- a/beowulf-core/src/main/java/com/beowulf/core/visitor/ArchiveLogQueryService.java
+++ b/beowulf-core/src/main/java/com/beowulf/core/visitor/ArchiveLogQueryService.java
@@ -1,0 +1,80 @@
+package com.beowulf.core.visitor;
+
+import com.beowulf.core.db.DataSourceFactory;
+
+import javax.sql.DataSource;
+import java.sql.*;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+public class ArchiveLogQueryService {
+
+    private final DataSource dataSource;
+
+    public ArchiveLogQueryService() {
+        this.dataSource = DataSourceFactory.getDataSource();
+    }
+
+    public List<ArchiveLogEntry> findRecentLogs(UUID userId, int limit) {
+        String sql = """
+                SELECT
+                    l.id                              AS log_id,
+                    l.created_at                      AS log_created_at,
+                    l.operation,
+                    l.status,
+                    l.duration_ms,
+                    a.path                            AS archive_path,
+                    a.format,
+                    a.compression,
+                    a.size_bytes,
+                    c.type                            AS checksum_type,
+                    c.value                           AS checksum_value
+                FROM archive_log l
+                JOIN archive a
+                  ON l.archive_id = a.id
+                JOIN checksum c
+                  ON a.checksum_id = c.id
+                WHERE l.user_id = ?
+                ORDER BY l.created_at DESC
+                LIMIT ?
+                """;
+
+        List<ArchiveLogEntry> result = new ArrayList<>();
+
+        try (Connection connection = dataSource.getConnection();
+                PreparedStatement preparedStatement = connection.prepareStatement(sql)) {
+
+            preparedStatement.setObject(1, userId);
+            preparedStatement.setInt(2, limit);
+
+            try (ResultSet resultSet = preparedStatement.executeQuery()) {
+                while (resultSet.next()) {
+                    ArchiveLogEntry entry = new ArchiveLogEntry();
+                    entry.setId(resultSet.getLong("log_id"));
+                    entry.setCreatedAt(resultSet.getObject("log_created_at", OffsetDateTime.class));
+                    entry.setOperation(resultSet.getString("operation"));
+                    entry.setStatus(resultSet.getString("status"));
+                    entry.setDurationMs(resultSet.getLong("duration_ms"));
+
+                    entry.setArchivePath(resultSet.getString("archive_path"));
+
+                    entry.setFormat(resultSet.getString("format"));
+                    entry.setCompression(resultSet.getString("compression"));
+                    entry.setSizeBytes(resultSet.getLong("size_bytes"));
+                    entry.setChecksumType(resultSet.getString("checksum_type"));
+                    entry.setChecksumValue(resultSet.getString("checksum_value"));
+
+                    result.add(entry);
+                }
+
+            }
+
+        } catch (SQLException error) {
+            throw new RuntimeException("Failed to load archive logs", error);
+        }
+
+        return result;
+    }
+}

--- a/beowulf-core/src/main/java/com/beowulf/core/visitor/ArchiveOperationContext.java
+++ b/beowulf-core/src/main/java/com/beowulf/core/visitor/ArchiveOperationContext.java
@@ -1,0 +1,134 @@
+package com.beowulf.core.visitor;
+
+import com.beowulf.core.user.AppUser;
+
+import java.util.UUID;
+
+public class ArchiveOperationContext implements LogVisitable {
+
+    private AppUser user;
+
+    private UUID archiveId;
+    private String format; // ZIP / TAR / ...
+    private String compression; // GZIP / LZMA / ...
+    private String archivePath;
+    private long sizeBytes;
+
+    private UUID checksumId;
+    private String checksumType; // CRC32, SHA256
+    private String checksumValue;
+
+    private String operation; // COMPRESS / DECOMPRESS
+    private String operationPath; // path involved (e.g. source or target)
+    private String status; // SUCCESS / FAILED
+    private long durationMs;
+
+    public AppUser getUser() {
+        return user;
+    }
+
+    public void setUser(AppUser user) {
+        this.user = user;
+    }
+
+    public UUID getArchiveId() {
+        return archiveId;
+    }
+
+    public void setArchiveId(UUID archiveId) {
+        this.archiveId = archiveId;
+    }
+
+    public String getFormat() {
+        return format;
+    }
+
+    public void setFormat(String format) {
+        this.format = format;
+    }
+
+    public String getCompression() {
+        return compression;
+    }
+
+    public void setCompression(String compression) {
+        this.compression = compression;
+    }
+
+    public String getArchivePath() {
+        return archivePath;
+    }
+
+    public void setArchivePath(String archivePath) {
+        this.archivePath = archivePath;
+    }
+
+    public long getSizeBytes() {
+        return sizeBytes;
+    }
+
+    public void setSizeBytes(long sizeBytes) {
+        this.sizeBytes = sizeBytes;
+    }
+
+    public UUID getChecksumId() {
+        return checksumId;
+    }
+
+    public void setChecksumId(UUID checksumId) {
+        this.checksumId = checksumId;
+    }
+
+    public String getChecksumType() {
+        return checksumType;
+    }
+
+    public void setChecksumType(String checksumType) {
+        this.checksumType = checksumType;
+    }
+
+    public String getChecksumValue() {
+        return checksumValue;
+    }
+
+    public void setChecksumValue(String checksumValue) {
+        this.checksumValue = checksumValue;
+    }
+
+    public String getOperation() {
+        return operation;
+    }
+
+    public void setOperation(String operation) {
+        this.operation = operation;
+    }
+
+    public String getOperationPath() {
+        return operationPath;
+    }
+
+    public void setOperationPath(String operationPath) {
+        this.operationPath = operationPath;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public long getDurationMs() {
+        return durationMs;
+    }
+
+    public void setDurationMs(long durationMs) {
+        this.durationMs = durationMs;
+    }
+
+    @Override
+    public void accept(LogVisitor visitor) {
+        visitor.visit(this);
+    }
+}

--- a/beowulf-core/src/main/java/com/beowulf/core/visitor/ArchivePersistenceService.java
+++ b/beowulf-core/src/main/java/com/beowulf/core/visitor/ArchivePersistenceService.java
@@ -1,0 +1,157 @@
+package com.beowulf.core.visitor;
+
+import com.beowulf.core.db.DataSourceFactory;
+import com.beowulf.core.user.AppUser;
+
+import javax.sql.DataSource;
+import java.sql.*;
+import java.util.UUID;
+
+public class ArchivePersistenceService {
+
+    private final DataSource dataSource;
+
+    public ArchivePersistenceService() {
+        this.dataSource = DataSourceFactory.getDataSource();
+    }
+
+    public void persistOperation(ArchiveOperationContext ctx) {
+        Connection connection = null;
+        try {
+            connection = dataSource.getConnection();
+            connection.setAutoCommit(false);
+
+            AppUser user = ctx.getUser();
+            upsertUser(connection, user);
+
+            UUID checksumId = ctx.getChecksumId() != null
+                    ? ctx.getChecksumId()
+                    : UUID.randomUUID();
+
+            insertChecksum(connection, checksumId,
+                    ctx.getChecksumType(), ctx.getChecksumValue());
+            ctx.setChecksumId(checksumId);
+
+            UUID archiveId = ctx.getArchiveId() != null
+                    ? ctx.getArchiveId()
+                    : UUID.randomUUID();
+
+            insertArchive(connection, archiveId, user.getId(), checksumId,
+                    ctx.getFormat(), ctx.getCompression(),
+                    ctx.getArchivePath(), ctx.getSizeBytes());
+            ctx.setArchiveId(archiveId);
+
+            insertArchiveLog(connection,
+                    user.getId(), archiveId,
+                    ctx.getOperation(),
+                    ctx.getStatus(),
+                    ctx.getDurationMs());
+
+            connection.commit();
+        } catch (SQLException error) {
+            safeRollback(connection);
+            throw new RuntimeException("Failed to persist archive operation", error);
+        } finally {
+            safeClose(connection);
+        }
+    }
+
+    private void upsertUser(Connection connection, AppUser user) throws SQLException {
+        String sql = """
+                INSERT INTO app_user (id, username)
+                VALUES (?, ?)
+                ON CONFLICT (id) DO UPDATE
+                    SET username = EXCLUDED.username
+                """;
+
+        try (PreparedStatement preparedStatement = connection.prepareStatement(sql)) {
+            preparedStatement.setObject(1, user.getId());
+            preparedStatement.setString(2, user.getUsername());
+            preparedStatement.executeUpdate();
+        }
+    }
+
+    private void insertChecksum(Connection connection,
+            UUID id,
+            String type,
+            String value) throws SQLException {
+        String sql = """
+                INSERT INTO checksum (id, type, value)
+                VALUES (?, ?, ?)
+                """;
+
+        try (PreparedStatement preparedStatement = connection.prepareStatement(sql)) {
+            preparedStatement.setObject(1, id);
+            preparedStatement.setString(2, type);
+            preparedStatement.setString(3, value);
+            preparedStatement.executeUpdate();
+        }
+    }
+
+    private void insertArchive(Connection connection,
+            UUID archiveId,
+            UUID userId,
+            UUID checksumId,
+            String format,
+            String compression,
+            String path,
+            long sizeBytes) throws SQLException {
+        String sql = """
+                INSERT INTO archive
+                    (id, user_id, checksum_id, format, compression, path, size_bytes)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                """;
+
+        try (PreparedStatement ps = connection.prepareStatement(sql)) {
+            ps.setObject(1, archiveId);
+            ps.setObject(2, userId);
+            ps.setObject(3, checksumId);
+            ps.setString(4, format);
+            ps.setString(5, compression);
+            ps.setString(6, path);
+            ps.setLong(7, sizeBytes);
+            ps.executeUpdate();
+        }
+    }
+
+    private void insertArchiveLog(Connection connection,
+            UUID userId,
+            UUID archiveId,
+            String operation,
+            String status,
+            long durationMs) throws SQLException {
+        String sql = """
+                INSERT INTO archive_log
+                (user_id, archive_id, operation, status, duration_ms)
+                VALUES (?, ?, ?, ?, ?)
+                """;
+
+        try (PreparedStatement ps = connection.prepareStatement(sql)) {
+            ps.setObject(1, userId);
+            ps.setObject(2, archiveId);
+            ps.setString(3, operation);
+            ps.setString(4, status);
+            ps.setLong(5, durationMs);
+            ps.executeUpdate();
+        }
+    }
+
+    private void safeRollback(Connection connection) {
+        if (connection != null) {
+            try {
+                connection.rollback();
+            } catch (SQLException ignored) {
+            }
+        }
+    }
+
+    private void safeClose(Connection connection) {
+        if (connection != null) {
+            try {
+                connection.setAutoCommit(true);
+                connection.close();
+            } catch (SQLException ignored) {
+            }
+        }
+    }
+}

--- a/beowulf-core/src/main/java/com/beowulf/core/visitor/LogVisitable.java
+++ b/beowulf-core/src/main/java/com/beowulf/core/visitor/LogVisitable.java
@@ -1,0 +1,5 @@
+package com.beowulf.core.visitor;
+
+public interface LogVisitable {
+    void accept(LogVisitor visitor);
+}

--- a/beowulf-core/src/main/java/com/beowulf/core/visitor/LogVisitor.java
+++ b/beowulf-core/src/main/java/com/beowulf/core/visitor/LogVisitor.java
@@ -1,0 +1,5 @@
+package com.beowulf.core.visitor;
+
+public interface LogVisitor {
+    void visit(ArchiveOperationContext context);
+}

--- a/beowulf-core/src/main/java/com/beowulf/core/visitor/LoggingArchiver.java
+++ b/beowulf-core/src/main/java/com/beowulf/core/visitor/LoggingArchiver.java
@@ -1,0 +1,171 @@
+package com.beowulf.core.visitor;
+
+import com.beowulf.core.strategy.Archiver;
+import com.beowulf.core.user.AppUser;
+import com.beowulf.core.user.LocalUserIdentityProvider;
+
+import java.io.IOException;
+import java.nio.file.*;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Locale;
+import java.util.UUID;
+
+public class LoggingArchiver implements Archiver {
+
+    private final Archiver delegate;
+    private final LocalUserIdentityProvider identityProvider;
+    private final PersistArchiveVisitor persistVisitor;
+
+    public LoggingArchiver(Archiver delegate,
+            LocalUserIdentityProvider identityProvider,
+            PersistArchiveVisitor persistVisitor) {
+        this.delegate = delegate;
+        this.identityProvider = identityProvider;
+        this.persistVisitor = persistVisitor;
+    }
+
+    @Override
+    public String getName() {
+        return delegate.getName();
+    }
+
+    @Override
+    public void compress(Path sourceDir, Path targetArchive) throws IOException {
+        AppUser user = identityProvider.resolveCurrentUser();
+        long started = System.currentTimeMillis();
+
+        delegate.compress(sourceDir, targetArchive);
+
+        long duration = System.currentTimeMillis() - started;
+
+        if (!Files.exists(targetArchive)) {
+            throw new IOException("Archive was not created: " + targetArchive);
+        }
+
+        long sizeBytes = Files.size(targetArchive);
+        String checksumValue = sha256Hex(targetArchive);
+
+        ArchiveOperationContext ctx = new ArchiveOperationContext();
+        ctx.setUser(user);
+
+        ctx.setArchiveId(UUID.randomUUID());
+        ctx.setFormat(detectFormat(targetArchive));
+        ctx.setCompression(detectCompression(targetArchive));
+        ctx.setArchivePath(targetArchive.toString());
+        ctx.setSizeBytes(sizeBytes);
+
+        ctx.setChecksumType("SHA256");
+        ctx.setChecksumValue(checksumValue);
+
+        ctx.setOperation("COMPRESS");
+        ctx.setOperationPath(sourceDir.toString());
+        ctx.setStatus("SUCCESS");
+        ctx.setDurationMs(duration);
+
+        ctx.accept(persistVisitor);
+    }
+
+    @Override
+    public void decompress(Path archive, Path targetDir) throws IOException {
+        AppUser user = identityProvider.resolveCurrentUser();
+        long started = System.currentTimeMillis();
+
+        if (!Files.exists(archive)) {
+            throw new IOException("Archive file not found: " + archive);
+        }
+
+        String checksumValue = sha256Hex(archive);
+        long sizeBytes = Files.size(archive);
+
+        String status = "SUCCESS";
+        try {
+            delegate.decompress(archive, targetDir);
+        } catch (IOException | RuntimeException error) {
+            status = "FAILED";
+            throw error;
+        } finally {
+            long duration = System.currentTimeMillis() - started;
+
+            ArchiveOperationContext ctx = new ArchiveOperationContext();
+            ctx.setUser(user);
+
+            ctx.setArchiveId(UUID.randomUUID());
+            ctx.setFormat(detectFormat(archive));
+            ctx.setCompression(detectCompression(archive));
+            ctx.setArchivePath(archive.toString());
+            ctx.setSizeBytes(sizeBytes);
+
+            ctx.setChecksumType("SHA256");
+            ctx.setChecksumValue(checksumValue);
+
+            ctx.setOperation("DECOMPRESS");
+            ctx.setOperationPath(targetDir.toString());
+            ctx.setStatus(status);
+            ctx.setDurationMs(duration);
+
+            ctx.accept(persistVisitor);
+        }
+    }
+
+    private String detectFormat(Path path) {
+        String name = path.getFileName().toString().toLowerCase(Locale.ROOT);
+        if (name.endsWith(".zip"))
+            return "ZIP";
+        if (name.endsWith(".tar.gz") || name.endsWith(".tgz"))
+            return "TAR";
+        if (name.endsWith(".tar.bz2") || name.endsWith(".tbz") || name.endsWith(".tbz2"))
+            return "TAR";
+        if (name.endsWith(".7z"))
+            return "7Z";
+        if (name.endsWith(".rar"))
+            return "RAR";
+        if (name.endsWith(".tar"))
+            return "TAR";
+        if (name.endsWith(".ace"))
+            return "ACE";
+        return "UNKNOWN";
+    }
+
+    private String detectCompression(Path path) {
+        String name = path.getFileName().toString().toLowerCase(Locale.ROOT);
+        if (name.endsWith(".zip"))
+            return "DEFLATE";
+        if (name.endsWith(".tar.gz") || name.endsWith(".tgz"))
+            return "GZIP";
+        if (name.endsWith(".tar.bz2") || name.endsWith(".tbz") || name.endsWith(".tbz2"))
+            return "BZIP2";
+        if (name.endsWith(".7z"))
+            return "LZMA";
+        if (name.endsWith(".rar"))
+            return "RAR";
+        if (name.endsWith(".tar"))
+            return "NONE";
+        if (name.endsWith(".ace"))
+            return "ACE";
+        return "UNKNOWN";
+    }
+
+    private String sha256Hex(Path path) throws IOException {
+        try {
+            MessageDigest messageDigest = MessageDigest.getInstance("SHA-256");
+            byte[] buffer = new byte[8192];
+
+            try (var in = Files.newInputStream(path)) {
+                int read;
+                while ((read = in.read(buffer)) != -1) {
+                    messageDigest.update(buffer, 0, read);
+                }
+            }
+
+            byte[] digest = messageDigest.digest();
+            StringBuilder stringBuilder = new StringBuilder(digest.length * 2);
+            for (byte b : digest) {
+                stringBuilder.append(String.format("%02x", b));
+            }
+            return stringBuilder.toString();
+        } catch (NoSuchAlgorithmException error) {
+            throw new RuntimeException("SHA-256 unsupported", error);
+        }
+    }
+}

--- a/beowulf-core/src/main/java/com/beowulf/core/visitor/PersistArchiveVisitor.java
+++ b/beowulf-core/src/main/java/com/beowulf/core/visitor/PersistArchiveVisitor.java
@@ -1,0 +1,15 @@
+package com.beowulf.core.visitor;
+
+public class PersistArchiveVisitor implements LogVisitor {
+
+    private final ArchivePersistenceService service;
+
+    public PersistArchiveVisitor(ArchivePersistenceService service) {
+        this.service = service;
+    }
+
+    @Override
+    public void visit(ArchiveOperationContext context) {
+        service.persistOperation(context);
+    }
+}

--- a/beowulf-core/src/main/resources/db/migration/V1__init.sql
+++ b/beowulf-core/src/main/resources/db/migration/V1__init.sql
@@ -1,0 +1,33 @@
+CREATE TABLE IF NOT EXISTS app_user (
+    id         UUID PRIMARY KEY,
+    username   TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS checksum (
+    id         UUID PRIMARY KEY,
+    type       VARCHAR(20) NOT NULL, -- CRC32 / SHA256
+    value      TEXT        NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS archive (
+    id          UUID PRIMARY KEY,
+    user_id     UUID      NOT NULL REFERENCES app_user(id) ON DELETE CASCADE,
+    checksum_id UUID      NOT NULL REFERENCES checksum(id) ON DELETE CASCADE,
+    format      VARCHAR(20) NOT NULL, -- ZIP / TAR / RAR / ACE
+    compression VARCHAR(20) NOT NULL, -- GZIP / BZIP2 / LZMA / XZ / ZSTD
+    path        TEXT        NOT NULL,
+    size_bytes  BIGINT      NOT NULL,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS archive_log (
+    id          BIGSERIAL PRIMARY KEY,
+    user_id     UUID      NOT NULL REFERENCES app_user(id) ON DELETE CASCADE,
+    archive_id  UUID      NOT NULL REFERENCES archive(id) ON DELETE CASCADE,
+    operation   VARCHAR(20) NOT NULL, -- COMPRESS / DECOMPRESS
+    status      VARCHAR(20) NOT NULL, -- SUCCESS / FAILED
+    duration_ms BIGINT      NOT NULL,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);

--- a/beowulf-core/src/test/java/com/beowulf/core/TarGzArchiverTest.java
+++ b/beowulf-core/src/test/java/com/beowulf/core/TarGzArchiverTest.java
@@ -24,7 +24,8 @@ class TarGzArchiverTest {
         archiver.compress(inputDir, archive);
         archiver.decompress(archive, outputDir);
 
-        Path extractedFile = outputDir.resolve("compress-me.txt");
+        Path extractedRootDir = outputDir.resolve(inputDir.getFileName());
+        Path extractedFile = extractedRootDir.resolve("compress-me.txt");
 
         assertTrue(Files.exists(archive), "Archive should exist after compression");
         assertTrue(Files.exists(extractedFile), "File should exist after decompression");

--- a/beowulf-core/src/test/java/com/beowulf/core/ZipArchiverTest.java
+++ b/beowulf-core/src/test/java/com/beowulf/core/ZipArchiverTest.java
@@ -24,7 +24,8 @@ class ZipArchiverTest {
         archiver.compress(inputDir, archive);
         archiver.decompress(archive, outputDir);
 
-        Path extractedFile = outputDir.resolve("compress-me.txt");
+        Path extractedRootDir = outputDir.resolve(inputDir.getFileName());
+        Path extractedFile = extractedRootDir.resolve("compress-me.txt");
 
         assertTrue(Files.exists(archive), "Archive should exist after compression");
         assertTrue(Files.exists(extractedFile), "File should exist after decompression");

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,26 @@
+services:
+  postgres:
+    image: postgres:15
+    container_name: beowulf-postgres
+    environment:
+      POSTGRES_USER: beowulf
+      POSTGRES_PASSWORD: beowulf
+      POSTGRES_DB: beowulf_db
+    ports:
+      - "5432:5432"
+    volumes:
+      - pg_data:/var/lib/postgresql/data
+
+  beowulf:
+    build: .
+    container_name: beowulf-cli
+    depends_on:
+      - postgres
+    volumes:
+      - ./data:/data
+      - beowulf_user_data:/root/.beowulf
+    entrypoint: ["./beowulf-cli/bin/beowulf-cli"]
+
+volumes:
+  pg_data:
+  beowulf_user_data:


### PR DESCRIPTION
# ✨ PostgreSQL DB + Visitors
- **Setted up PostgreSQL DB with Flyway + HikariCP**
- **Created relevant Visitors for collecting metadata**
- **Modified compression to preserve root input folder**
- **Updated CLI with `beowulf logs [limit]` command to display user history**<img width="696" height="291" alt='logs' src="https://github.com/user-attachments/assets/edf128ab-593b-4ca3-aa65-61f901e56f90" />
- **Setted up Dockerfile**